### PR TITLE
Implement ReducedPrivileges filesystem support.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,13 @@
+Version 0.9.18
+
+    * Fix spurious tar file header emitted for unreadable files.
+    * Add 'ignore_inaccessible' option to tar() method.
+    * Add ReducedPrivileges filesystem.
+    * Add 'recursion_mode' option to find() method.
+    * Fix handling of 'detached' inodes in Real directories.
+    * Fix handling of inodes named '0'
+    * Make alias() copy symlinks instead of the symlink targets.
+
 Version 0.9.17
 
     * Revert _write_file() refactor until further investigation is complete

--- a/MANIFEST
+++ b/MANIFEST
@@ -31,6 +31,9 @@ lib/Filesys/POSIX/Userland/Tar/Header.pm
 lib/Filesys/POSIX/Userland/Test.pm
 lib/Filesys/POSIX/VFS.pm
 lib/Filesys/POSIX/VFS/Inode.pm
+lib/Filesys/POSIX/ReducedPrivileges.pm
+lib/Filesys/POSIX/ReducedPrivileges/Directory.pm
+lib/Filesys/POSIX/ReducedPrivileges/Inode.pm
 LICENSE
 Makefile.PL
 MANIFEST			This list of files
@@ -64,3 +67,4 @@ t/test.t
 t/umask.t
 t/userland.t
 t/vfs.t
+t/reducedprivileges.t

--- a/lib/Filesys/POSIX.pm
+++ b/lib/Filesys/POSIX.pm
@@ -24,7 +24,7 @@ use Filesys::POSIX::Error qw(throw);
 
 use Carp qw(confess);
 
-our $VERSION = '0.9.17';
+our $VERSION = '0.9.18';
 
 =head1 NAME
 
@@ -148,7 +148,7 @@ sub _find_inode {
         #
         # We've encountered an absolute path.  Start from the beginning.
         #
-        unless ($item) {
+        unless (length $item) {
             $dir = $self->{'root'};
             next;
         }

--- a/lib/Filesys/POSIX/Extensions.pm
+++ b/lib/Filesys/POSIX/Extensions.pm
@@ -148,7 +148,7 @@ sub alias {
     my ( $self, $src, $dest ) = @_;
     my $hier      = Filesys::POSIX::Path->new($dest);
     my $name      = $hier->basename;
-    my $inode     = $self->stat($src);
+    my $inode     = $self->lstat($src);
     my $parent    = $self->stat( $hier->dirname );
     my $directory = $parent->directory;
 

--- a/lib/Filesys/POSIX/Real/Inode.pm
+++ b/lib/Filesys/POSIX/Real/Inode.pm
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, cPanel, Inc.
+# Copyright (c) 2016, cPanel, Inc.
 # All rights reserved.
 # http://cpanel.net/
 #
@@ -97,7 +97,8 @@ sub child {
         $inode = Filesys::POSIX::Mem::Inode->new( %data, 'mode' => $mode );
     }
     else {
-        $inode = __PACKAGE__->from_disk( $path, %data );
+        my $class = ref $self;
+        $inode = $class->from_disk( $path, %data );
     }
 
     return $directory->set( $name, $inode );

--- a/lib/Filesys/POSIX/ReducedPrivileges.pm
+++ b/lib/Filesys/POSIX/ReducedPrivileges.pm
@@ -1,0 +1,132 @@
+package Filesys::POSIX::ReducedPrivileges;
+
+# Copyright (c) 2016, cPanel, Inc.
+# All rights reserved.
+# http://cpanel.net/
+#
+# This is free software; you can redistribute it and/or modify it under the same
+# terms as Perl itself.  See the LICENSE file for further details.
+
+use Filesys::POSIX::Error qw(throw);
+use Filesys::POSIX::ReducedPrivileges::Inode ();
+use Filesys::POSIX::Real;
+use Carp  ();
+use Errno ();
+
+our @ISA = qw(Filesys::POSIX::Real);
+
+=head1 NAME
+
+Filesys::POSIX::ReducedPrivileges - Portal to actual underlying filesystem as seen by a particular UID/GID.
+
+=head1 SYNOPSIS
+
+    use Filesys::POSIX;
+    use Filesys::POSIX::Real;
+
+    my $fs = Filesys::POSIX->new(Filesys::POSIX::ReducedPrivileges->new,
+        'path'    => '/home/foo/test',
+        'noatime' => 1,
+        'uid'     => 99,
+        'gid'     => 99,
+    );
+
+=head1 DESCRIPTION
+
+This module wraps the L<Filesys::POSIX::Real> filesystem type with entry and
+exit functions that switch the effective UID and GID whenever the filesystem
+is accessed.
+
+=head1 MOUNT OPTIONS
+
+The following values are mandatory:
+
+=over
+
+=item C<path>
+
+The path, in the real filesystem, upon which the new filesystem to be mounted
+will be based.
+
+=item C<uid>
+
+The numeric UID to use when accessing the real filesystem.
+
+=item C<gid>
+
+The numeric GID to use when accessing the real filesystem. The suppelemental
+group list is also limited to this GID.
+
+=back
+
+=cut
+
+sub new {
+    my ( $class, %opts ) = @_;
+    my $self = $class->SUPER::new();
+
+    bless $self, $class;
+
+    return $self;
+}
+
+sub init {
+    my ( $self, %opts ) = @_;
+    my $path = $opts{'path'} or throw &Errno::EINVAL;
+
+    $self->{_uid}                = $opts{uid};
+    $self->{_gid}                = "$opts{gid} $opts{gid}";
+    $self->{_privileges_reduced} = 0;
+
+    my $root = Filesys::POSIX::ReducedPrivileges::Inode->from_disk( $path, 'dev' => $self );
+
+    throw &Errno::ENOTDIR unless $root->dir;
+
+    $self->{'flags'} = \%opts;
+    $self->{'path'}  = Filesys::POSIX::Path->full($path);
+    $self->{'root'}  = $root;
+
+    return $sel;
+}
+
+sub enter_filesystem {
+    my $self = shift;
+    $self->{_privileges_reduced}++;
+    return unless ( $self->{_privileges_reduced} == 1 );
+    $self->{_original_uid} = $>;
+    $self->{_original_gid} = $);
+    $)                     = $self->{_gid};
+    $>                     = $self->{_uid};
+    no warnings 'numeric';
+
+    unless ( $> == $self->{_uid} && int($)) eq int( $self->{_gid} ) ) {
+        Carp::confess("failed to reduce privileges: $!");
+    }
+    return;
+}
+
+sub exit_filesystem {
+    my $self = shift;
+    $self->{_privileges_reduced}--;
+    return unless ( $self->{_privileges_reduced} == 0 );
+    $> = $self->{_original_uid};
+    $) = $self->{_original_gid};
+    no warnings 'numeric';
+    unless ( $> == $self->{_original_uid} && int($)) eq int( $self->{_original_gid} ) ) {
+        Carp::confess("failed to restore privileges: $!");
+    }
+    return;
+}
+
+1;
+
+__END__
+
+=head1 AUTHOR
+
+Written by John Lightsey <jd@cpanel.net>
+
+=head1 COPYRIGHT
+
+Copyright (c) 2016, cPanel, Inc.  Distributed under the terms of the Perl
+Artistic license.

--- a/lib/Filesys/POSIX/ReducedPrivileges/Directory.pm
+++ b/lib/Filesys/POSIX/ReducedPrivileges/Directory.pm
@@ -1,0 +1,95 @@
+package Filesys::POSIX::ReducedPrivileges::Directory;
+
+# Copyright (c) 2016, cPanel, Inc.
+# All rights reserved.
+# http://cpanel.net/
+#
+# This is free software; you can redistribute it and/or modify it under the same
+# terms as Perl itself.  See the LICENSE file for further details.
+
+use strict;
+use warnings;
+
+use Filesys::POSIX::Real::Directory ();
+use Carp                            ();
+use Try::Tiny;
+
+our @ISA = qw(Filesys::POSIX::Real::Directory);
+our $AUTOLOAD;
+
+sub new {
+    my ( $class, $path, $inode ) = @_;
+    unless ( defined $inode->{dev} && ref $inode->{dev} && $inode->{dev}->isa('Filesys::POSIX::ReducedPrivileges') ) {
+        Carp::confess("invalid filesystem device");
+    }
+
+    return $class->SUPER::new( $path, $inode );
+}
+
+sub _sync_member {
+    my ( $self, $name ) = @_;
+    $self->{inode}{dev}->enter_filesystem();
+    try {
+        my $subpath = "$self->{'path'}/$name";
+        my @st      = lstat $subpath;
+
+        if ( scalar @st == 0 && $!{'ENOENT'} ) {
+            delete $self->{'members'}->{$name};
+        }
+        else {
+
+            Carp::confess($!) unless @st;
+
+            if ( exists $self->{'members'}->{$name} ) {
+                $self->{'members'}->{$name}->update(@st);
+            }
+            else {
+                $self->{'members'}->{$name} = Filesys::POSIX::ReducedPrivileges::Inode->from_disk(
+                    $subpath,
+                    'st_info' => \@st,
+                    'dev'     => $self->{'inode'}->{'dev'},
+                    'parent'  => $self->{'inode'}
+                );
+            }
+        }
+    }
+    catch {
+        $self->{inode}{dev}->exit_filesystem();
+        die $_;
+    };
+    $self->{inode}{dev}->exit_filesystem();
+    return;
+}
+
+# Wrap all of the normal Inode methods with privilege dropping and restoring.
+BEGIN {
+    foreach my $method (qw(_sync_all rename_member delete open rewind read close)) {
+        my $super_method = "SUPER::$method";
+        no strict 'refs';
+        *{ __PACKAGE__ . "::$method" } = sub {
+            my ( $self, @args ) = @_;
+            $self->{inode}{dev}->enter_filesystem();
+            my $context = wantarray();
+            my @result;
+            try {
+                if ($context) {
+                    @result = $self->$super_method(@args);
+                }
+                elsif ( defined $context ) {
+                    @result = ( scalar $self->$super_method(@args) );
+                }
+                else {
+                    $self->$super_method(@args);
+                }
+            }
+            catch {
+                $self->{inode}{dev}->exit_filesystem();
+                die $_;
+            };
+            $self->{inode}{dev}->exit_filesystem();
+            return $context ? @result : defined $context ? $result[0] : ();
+        };
+    }
+}
+
+1;

--- a/lib/Filesys/POSIX/ReducedPrivileges/Inode.pm
+++ b/lib/Filesys/POSIX/ReducedPrivileges/Inode.pm
@@ -1,0 +1,93 @@
+package Filesys::POSIX::ReducedPrivileges::Inode;
+
+# Copyright (c) 2016, cPanel, Inc.
+# All rights reserved.
+# http://cpanel.net/
+#
+# This is free software; you can redistribute it and/or modify it under the same
+# terms as Perl itself.  See the LICENSE file for further details.
+
+use strict;
+use warnings;
+
+use Filesys::POSIX::ReducedPrivileges::Directory ();
+use Filesys::POSIX::Real::Inode                  ();
+use Filesys::POSIX::Mem::Inode                   ();
+use Filesys::POSIX::Bits;
+use Filesys::POSIX::Bits::System;
+use Filesys::POSIX::Error qw(throw);
+use Carp ();
+
+use Fcntl qw(:DEFAULT :mode);
+use Try::Tiny;
+
+our @ISA = qw(Filesys::POSIX::Real::Inode);
+our $AUTOLOAD;
+
+sub new {
+    my ( $class, $path, %opts ) = @_;
+    unless ( defined $opts{dev} && ref $opts{dev} && $opts{dev}->isa('Filesys::POSIX::ReducedPrivileges') ) {
+        Carp::confess("invalid filesystem device");
+    }
+
+    # No need to enter the ReducedContext for new. No file operations are performed.
+    # Typically new() is called by from_disk() anyway
+    return $class->SUPER::new( $path, %opts );
+}
+
+sub from_disk {
+    my ( $class, $path, %opts ) = @_;
+    unless ( defined $opts{dev} && ref $opts{dev} && $opts{dev}->isa('Filesys::POSIX::ReducedPrivileges') ) {
+        Carp::confess("invalid filesystem device");
+    }
+
+    my $self;
+    $opts{dev}->enter_filesystem();
+    try {
+        $self = $class->SUPER::from_disk( $path, %opts );
+    }
+    catch {
+        $opts{dev}->exit_filesystem();
+        die $_;
+    };
+
+    $opts{dev}->exit_filesystem();
+
+    # Fix the class of the directory object
+    bless $self->{directory}, 'Filesys::POSIX::ReducedPrivileges::Directory' if ( ref $self->{directory} );
+
+    return $self;
+}
+
+# Wrap the normal Inode methods that do actual filesystem activity with privilege dropping and restoring.
+BEGIN {
+    foreach my $method (qw(open chown chmod readlink symlink child)) {
+        my $super_method = "SUPER::$method";
+        no strict 'refs';
+        *{ __PACKAGE__ . "::$method" } = sub {
+            my ( $self, @args ) = @_;
+            $self->{dev}->enter_filesystem();
+            my $context = wantarray();
+            my @result;
+            try {
+                if ($context) {
+                    @result = $self->$super_method(@args);
+                }
+                elsif ( defined $context ) {
+                    @result = ( scalar $self->$super_method(@args) );
+                }
+                else {
+                    $self->$super_method(@args);
+                }
+            }
+            catch {
+                $self->{dev}->exit_filesystem();
+                die $_;
+            };
+            $self->{dev}->exit_filesystem();
+            return $context ? @result : defined $context ? $result[0] : ();
+        };
+    }
+}
+
+1;

--- a/t/extensions.t
+++ b/t/extensions.t
@@ -16,7 +16,7 @@ use Filesys::POSIX::Bits;
 
 use File::Temp ();
 
-use Test::More ( 'tests' => 11 );
+use Test::More ( 'tests' => 13 );
 use Test::Exception;
 use Test::NoWarnings;
 use Test::Filesys::POSIX::Error;
@@ -82,6 +82,14 @@ my $inode = $fs->stat('/bin/sh');
         $fs->alias( '/bin/sh', '/mnt/mem/bin/bash' );
     }
     &Errno::EEXIST, "Filesys::POSIX->alias() will complain when destination exists";
+
+    $fs->symlink( '/mnt/mem/bin/missing', '/mnt/mem/bin/missingsymlink' );
+    $fs->alias( '/mnt/mem/bin/missingsymlink', '/mnt/mem/bin/missingsymlinkalias' );
+    ok( $fs->lstat('/mnt/mem/bin/missingsymlinkalias'), 'Alias to dangling symlink created' );
+    throws_errno_ok {
+        $fs->stat('/mnt/mem/bin/missingsymlinkalias');
+    }
+    &Errno::ENOENT, "Symlink is still dangling after alias";
 }
 
 #

--- a/t/mount.t
+++ b/t/mount.t
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, cPanel, Inc.
+# Copyright (c) 2016, cPanel, Inc.
 # All rights reserved.
 # http://cpanel.net/
 #
@@ -8,11 +8,12 @@
 use strict;
 use warnings;
 
-use Filesys::POSIX      ();
-use Filesys::POSIX::Mem ();
+use Filesys::POSIX       ();
+use Filesys::POSIX::Mem  ();
+use Filesys::POSIX::Real ();
 use Filesys::POSIX::Bits;
 
-use Test::More ( 'tests' => 30 );
+use Test::More ( 'tests' => 32 );
 use Test::Exception;
 use Test::NoWarnings;
 use Test::Filesys::POSIX::Error;
@@ -145,6 +146,20 @@ foreach ( sort keys %$mounts ) {
     $fs->chdir('/');
 
     $fs->close($fd);
+}
+
+{
+    $fs->mkdir("real");
+    $fs->mkdir("real/0");
+    my $inode = eval { $fs->stat('real/0') };
+    ok($inode, 'Mkdir of real/0 succeeded');
+    diag($@) if $@;
+
+    $fs->mount( Filesys::POSIX::Real->new, 'real/0', path => '/' );
+    $inode = eval { $fs->stat('real/0/etc/passwd') };
+    ok( $inode, 'Mount at real/0 functions properly' );
+    diag($@) if $@;
+    $fs->unmount('real/0');
 }
 
 {

--- a/t/reducedprivileges.t
+++ b/t/reducedprivileges.t
@@ -1,0 +1,93 @@
+#!/usr/bin/perl
+
+# Copyright (c) 2016, cPanel, Inc.
+# All rights reserved.
+# http://cpanel.net/
+#
+# This is free software; you can redistribute it and/or modify it under the same
+# terms as Perl itself.  See the LICENSE file for further details.
+
+use strict;
+use warnings;
+
+use Filesys::POSIX                    ();
+use Filesys::POSIX::ReducedPrivileges ();
+use Filesys::POSIX::Bits;
+
+use File::Temp ();
+use Fcntl;
+
+use Test::More;
+
+BEGIN {
+    if ( $> == 0 ) {
+        plan tests => 13;
+    }
+    else {
+        plan skip_all => 'Privilege droppping tests require root';
+    }
+}
+
+use Test::Exception;
+use Test::NoWarnings;
+use Test::Filesys::POSIX::Error;
+
+my $tmpdir = File::Temp::tempdir( 'CLEANUP' => 1 );
+chmod( 0755, $tmpdir );
+
+my %files = (
+    'foo'          => 'file',
+    'bar'          => 'dir',
+    'bar/baz'      => 'dir',
+    'bar/boo'      => 'dir',
+    'bar/boo/cats' => 'file'
+);
+
+foreach ( sort keys %files ) {
+    my $path = "$tmpdir/$_";
+
+    if ( $files{$_} eq 'file' ) {
+        sysopen( my $fh, $path, O_CREAT );
+        close($fh);
+    }
+    elsif ( $files{$_} eq 'dir' ) {
+        mkdir($path);
+    }
+}
+
+my $fs = Filesys::POSIX->new( Filesys::POSIX::ReducedPrivileges->new, uid => 99, gid => 99, 'path' => $tmpdir );
+
+foreach ( sort keys %files ) {
+    my $inode = $fs->stat($_);
+
+    if ( $files{$_} eq 'file' ) {
+        ok( $inode->file, "Filesys::POSIX::ReducedPrivileges sees $_ as a file" );
+        ok(
+            $inode->{'size'} == 0,
+            "Filesys::POSIX::ReducedPrivileges sees $_ as a 0 byte file"
+        );
+    }
+    elsif ( $files{$_} eq 'dir' ) {
+        ok( $inode->dir, "Filesys::POSIX::ReducedPrivileges sees $_ as a directory" );
+    }
+}
+
+throws_errno_ok {
+    Filesys::POSIX->new( Filesys::POSIX::ReducedPrivileges->new, uid => 99, gid => 99 );
+}
+&Errno::EINVAL, "Filesys::POSIX::ReducedPrivileges->init() dies when no path is specified";
+
+throws_errno_ok {
+    Filesys::POSIX->new( Filesys::POSIX::ReducedPrivileges->new, uid => 99, gid => 99, 'path' => '/dev/null' );
+}
+&Errno::ENOTDIR, "Filesys::POSIX::ReducedPrivileges->init() dies when special is not a directory";
+
+TODO: {
+    local $TODO = "Rename failures currently not implemented in Filesys::POSIX::Real";
+    dies_ok {
+        $fs->rename( 'foo', 'bleh' );
+    }
+    "Filesys::POSIX->rename() fails to renaming file in root owned directory";
+}
+ok( -e "$tmpdir/foo",   "Original filename remains after failed rename" );
+ok( !-e "$tmpdir/bleh", "New filename was not created by failed rename" );

--- a/t/rename.t
+++ b/t/rename.t
@@ -1,5 +1,5 @@
 #!/usr/local/cpanel/3rdparty/bin/perl
-# cpanel - t/rename.t                             Copyright(c) 2014 cPanel, Inc.
+# cpanel - t/rename.t                             Copyright(c) 2016 cPanel, Inc.
 #                                                           All rights Reserved.
 # copyright@cpanel.net                                         http://cpanel.net
 # This code is subject to the cPanel license. Unauthorized copying is prohibited
@@ -7,7 +7,7 @@
 use strict;
 use warnings;
 
-use Test::More ( 'tests' => 4 );
+use Test::More ( 'tests' => 2 );
 use Test::Deep;
 use Test::Exception;
 use Test::NoWarnings;
@@ -55,42 +55,4 @@ my $do_tar = sub {
     }
 
     is( scalar @expected => scalar keys %found, 'Found the correct number of items archived' );
-}
-
-#
-# Sanity check: If we use the wrong rename_member method, we get the old, wrong
-# behavior for "Real" that forgets to update the state of the real filesystem.
-# (This is still correct for Directory objects that aren't based on a real
-# filesystem, though.)
-#
-{
-    my @expected = qw(dir dir/item2.txt dir/item3.txt);
-
-    my %found;
-
-    local *Filesys::POSIX::Real::Directory::rename_member;
-
-    $fs->rename( 'dir/item2.txt' => 'dir/item3.txt' );
-
-    my @items = $do_tar->();
-
-    foreach my $item (@items) {
-        foreach my $expected_item (@expected) {
-            $found{$item} = 1 if $item =~ /\Q$expected_item\E(?:|\/)$/;
-        }
-    }
-
-    is( scalar @expected => scalar keys %found, 'Found the correct number of items archived after usage of rename_member()' );
-}
-
-# Further sanity check: Prove that the parent class's rename_member method is the one being
-# used in the previous sanity check.
-{
-    local *Filesys::POSIX::Real::Directory::rename_member;
-    local *Filesys::POSIX::Directory::rename_member;
-
-    throws_ok {
-        $fs->rename( 'dir/item3.txt' => 'dir/item4.txt' );
-    }
-    qr/Can't locate object method "rename_member" via package/, "Further sanity check: The rename_member method was provided only by the class(es) we expected";
 }


### PR DESCRIPTION
This implements a new ReducedPrivileges filesystem type that
changes UID and GID whenever the underlying real filesystem is
accessed.

It also implements new options for the tar() and find() methods
that will limit the number of filesystem changes that are made
during recursion to improve performance with the ReducedPrivileges
filesystem type.

Several minor bugs were also corrected:
 - spurious tar header emitted for unreadable files
 - incorrect handling of 'detached' inodes in Real directories
 - incorrect handling of inodes named '0'
 - alias was copying symlink target rather than the symlink
 - some error states were throwing misformatted errors