### PR TITLE
Skip detached inodes in F::P::R::D::read()

### DIFF
--- a/lib/Filesys/POSIX/Real/Directory.pm
+++ b/lib/Filesys/POSIX/Real/Directory.pm
@@ -219,7 +219,7 @@ sub read {
         else {
             $item = each %{ $self->{'skipped'} };
         }
-    } while ( $item && $self->{'detached'}->{$item} );
+    } while ( $item && exists $self->{'detached'}->{$item} );
 
     if (wantarray) {
         return ( $item, $self->get($item) );


### PR DESCRIPTION
Filesys::POSIX::Real::Directory::read() isn't skipping detached inodes causes
the subsequent ->get() call to return undef. This doesn't break pkgacct, but
generates the same type of error an inaccessible inode would generate.

Credit to JD for providing the patch.